### PR TITLE
fix --additional flag adding .tiff to filename that already have .tiff

### DIFF
--- a/brainreg/backend/niftyreg/run.py
+++ b/brainreg/backend/niftyreg/run.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 import bg_space as bg
 import imio
@@ -178,18 +179,26 @@ def run_niftyreg(
         for name, filename in additional_images_downsample.items():
             logging.info(f"Processing: {name}")
 
+            name_to_save = (
+                Path(name).stem
+                if name.lower().endswith((".tiff", ".tif"))
+                else name
+            )
+
             downsampled_brain_path = os.path.join(
-                registration_output_folder, f"downsampled_{name}.tiff"
+                registration_output_folder, f"downsampled_{name_to_save}.tiff"
             )
             tmp_downsampled_brain_path = os.path.join(
-                niftyreg_paths.niftyreg_directory, f"downsampled_{name}.nii"
+                niftyreg_paths.niftyreg_directory,
+                f"downsampled_{name_to_save}.nii",
             )
             downsampled_brain_standard_path = os.path.join(
-                registration_output_folder, f"downsampled_standard_{name}.tiff"
+                registration_output_folder,
+                f"downsampled_standard_{name_to_save}.tiff",
             )
             tmp_downsampled_brain_standard_path = os.path.join(
                 niftyreg_paths.niftyreg_directory,
-                f"downsampled_standard_{name}.nii",
+                f"downsampled_standard_{name_to_save}.nii",
             )
 
             # do the tiff part at the beginning


### PR DESCRIPTION
This merge will fix the additional .tiff extension if a .tiff file is passed to --additional flag, addresses brainglobe/brainreg#83

This could more succinctly be fixed by editing [here](https://github.com/JoeZiminski/brainreg/blob/a500e3cae7a88b9c9892a29a21795d9a0cad5d66/brainreg/cli.py#L186), happy to change to this but thought there was a higher chance of breaking some else with this high-level change.

